### PR TITLE
feat(1): Add route for SSL ACME challenge

### DIFF
--- a/routes/index.js
+++ b/routes/index.js
@@ -4,6 +4,7 @@ const { Router } = require('express')
 
 const router = Router()
 
+router.use('/', require('./ssl'))
 router.use('/', require('./home'))
 router.use('/enqueue', require('./enqueue'))
 router.use('/thumbnail', require('./thumbnail'))

--- a/routes/ssl.js
+++ b/routes/ssl.js
@@ -1,0 +1,11 @@
+'use strict'
+
+const { Router } = require('express')
+  
+const router = Router()
+
+router.get('/.well-known/acme-challenge/:content', (req, res) => {
+  res.send(`${req.params.content}.hZPQ8UhdGPeVfaXI2g7IIfxm20GiQgmoVJtZ3kT4Wg8`)
+})
+  
+module.exports = router


### PR DESCRIPTION
## Context

Visiting https://www.4webm.org will result in an error response:

```
ERR_SSL_PROTOCOL_ERROR
```

`https` is not supported since SSL has not been configured. Heroku ACM is failing to automatically provision an SSL certificate, so I'm attempting to provision an SSL certificate manually.

## Objective

* Add an endpoint for `certbot` to hit, to confirm that I'm the owner of 4webm.org

## Reference

* Issue: https://github.com/ScottyFillups/4webm/issues/1
* Helpful guide: https://medium.com/@franxyzxyz/setting-up-free-https-with-heroku-ssl-and-lets-encrypt-80cf6eac108e