### PR TITLE
fix(travis): Add dummy test

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "scripts": {
     "start": "./bin/www",
     "dev": "nodemon ./bin/www --ignore /static --ignore /client",
+    "test": "echo \"No test specified!\"",
     "watch": "webpack --watch",
     "build": "webpack"
   },


### PR DESCRIPTION
## Context

Travis-CI is failing, since there is no `test` script in `package.json`.

## Objective

* Add a script, `yarn run test`, which will exit `0` to let the build pass