### PR TITLE
fix(redirect): Use redirect before registering routes

### DIFF
--- a/app.js
+++ b/app.js
@@ -7,13 +7,13 @@ const enforce = require('express-sslify')
 
 const app = express()
 
+if (process.env.NODE_ENV === 'production') {
+  app.use(enforce.HTTPS({ trustProtoHeader: true }))
+}
+
 app.enable('trust proxy')
 app.set('view engine', 'hbs')
 app.use(routes)
 app.use(express.static(path.join(__dirname, './static')))
-
-if (process.env.NODE_ENV === 'production') {
-  app.use(enforce.HTTPS({ trustProtoHeader: true }))
-}
 
 module.exports = app


### PR DESCRIPTION
## Context

`express-sslify` is used after registering routes, so SSL redirects don't work.

## Objective

* Change ordering to fix HTTPS redirect

## Lessons learned

* Push directly to Heroku if you want to confirm HTTPS works (assuming barely anybody uses your app, lol :stuck_out_tongue_winking_eye:)