### PR TITLE
fix(https): Ensure HTTPS is enabled for external content

### DIFF
--- a/routes/enqueue.js
+++ b/routes/enqueue.js
@@ -21,7 +21,7 @@ router.get('/:board/thread/:threadNo', (req, res) => {
 
   fs.ensureDir(dir)
     .then(() => Promise.all([
-      throttledListWebms(board, threadNo),
+      throttledListWebms(board, threadNo, { https: true }),
       fs.readdir(dir)
     ]))
     .then((arr) => {


### PR DESCRIPTION
## Context

Even though `https` is enabled, users will get a warning, `connection to this site is not fully secure`, since `http` is used to fetch content from 4chan.org

## Objective

* Enable the `https` option for `4chan-list-webm`

## Lessons learned

* A site is only fully secure if _all_ its content is transferred via `https`