### PR TITLE
fix(thumb): Fix thumbnail display

### DIFF
--- a/routes/enqueue.js
+++ b/routes/enqueue.js
@@ -15,7 +15,7 @@ const router = Router()
 const throttledListWebms = limiter.wrap(listWebms)
 
 router.get('/:board/thread/:threadNo', (req, res) => {
-  const reg = /http:\/\/i\.4cdn\.org\/(.*)\/(.*)/g
+  const reg = /https:\/\/i\.4cdn\.org\/(.*)\/(.*)/g
   const { board, threadNo } = req.params
   const dir = path.join(__dirname, `../thumbnail/${board}/${threadNo}`)
 


### PR DESCRIPTION
## Context

4chan refuses to serve thumbnail images if requested from a cross-origin. The regular expression (see code) wasn't updated to reflect the change from `http` to `https`, and didn't transform the thumbnail image URL properly.

## Objective

* Fix regex to serve cached thumbnails

## Lessons learned

* I really should be adding tests :weary: 