### PR TITLE
refactor(load): Refactor client player logic

### DIFF
--- a/client/player.js
+++ b/client/player.js
@@ -22,14 +22,12 @@ class Player {
     const threadRegex = /(.*)\/(.*)\/thread\/(.*)/g
     const [,, board, threadNo] = threadRegex.exec(threadUrl)
 
-    this._playlist.reset()
-    this._playlist.load()
+    this._playlist.flash('Loading...')
 
     axios.get(`/enqueue/${board}/thread/${threadNo}`)
       .then(res => {
         const collect = collector(res.data)
 
-        this._playlist.reset()
         this._webmUrls = collect('url')
         this._playlist.gen(
           collect('filename'),

--- a/client/playlist.js
+++ b/client/playlist.js
@@ -7,6 +7,8 @@ class Playlist {
   }
 
   gen (filenames, thumbnails, handler) {
+    this._reset()
+
     filenames.forEach((filename, i) => {
       const $a = document.createElement('a')
       const $img = document.createElement('img')
@@ -43,14 +45,15 @@ class Playlist {
       })
   }
 
-  load () {
+  flash (msg) {
     const $msg = document.createElement('p')
-    $msg.innerHTML = 'Loading...'
+    $msg.innerHTML = msg
 
+    this._reset()
     this._$playlist.appendChild($msg)
   }
 
-  reset () {
+  _reset () {
     while (this._$playlist.firstChild) {
       this._$playlist.removeChild(this._$playlist.firstChild)
     }


### PR DESCRIPTION
## Context

Currently, the playlist DOM must manually be reset when generating a new playlist, or displaying a "flash message" (ie. "Loading...").

## Objective

* Replace `load` method with `flash`, which takes a string argument and creates a "flash message" in the playlist
* Make `reset` a private method; `gen` and `flash` now utilize it