### PR TITLE
feat(11): Load specific video from URL fragment

### DIFF
--- a/client/player.js
+++ b/client/player.js
@@ -19,8 +19,10 @@ class Player {
   }
 
   load (threadUrl) {
-    const threadRegex = /(.*)\/(.*)\/thread\/(.*)/g
-    const [,, board, threadNo] = threadRegex.exec(threadUrl)
+    const threadRegex = /(.*)\/(.*)\/thread\/(\d*)(#\d*)?/g
+    const [,, board, threadNo, fragment] = threadRegex.exec(threadUrl)
+
+    const index = fragment ? Number(fragment.slice(1) - 1) : 0
 
     this._playlist.flash('Loading...')
 
@@ -34,7 +36,7 @@ class Player {
           collect('thumbnail'),
           this.play.bind(this)
         )
-        this.play(0)
+        this.play(index)
       })
       .catch(console.log)
   }

--- a/client/playlist.js
+++ b/client/playlist.js
@@ -11,19 +11,25 @@ class Playlist {
 
     filenames.forEach((filename, i) => {
       const $a = document.createElement('a')
+      const $imgLink = document.createElement('a')
       const $img = document.createElement('img')
       const $div = document.createElement('div')
+      const num = i + 1
 
-      $a.innerHTML = `${i + 1}. ${filename}.webm`
+      $a.innerHTML = `${num}. ${filename}.webm`
       $a.className = 'webm-link'
+      $a.href = `#${num.toString()}`
+      
       $a.addEventListener('click', () => handler(i))
 
       $img.src = thumbnails[i]
       $img.className = 'thumbnail'
       $img.addEventListener('click', () => handler(i))
+      $imgLink.href = $a.href
+      $imgLink.appendChild($img)
 
       $div.className = 'playlist-item'
-      $div.appendChild($img)
+      $div.appendChild($imgLink)
       $div.appendChild($a)
 
       this._$playlist.appendChild($div)


### PR DESCRIPTION
## Context

Currently, it's not possible to send a link to a specific video in a 4webm playlist; all URLs (eg. https://boards.4webm.org/wsg/thread/1234) default to playing the first video in the playlist. 

## Objective

* Make number in fragment URL load nth video
  * Eg. https://boards.4webm.org/wsg/thread/1234#3 will load the 3rd video

## References

* Issue: https://github.com/ScottyFillups/4webm/issues/11