### PR TITLE
feat(error): Display 404 errors to user

### DIFF
--- a/client/player.js
+++ b/client/player.js
@@ -28,7 +28,7 @@ class Player {
     try {
       res = await axios.get(`/enqueue/${board}/thread/${threadNo}`)
     } catch (err) {
-      this._playlist.flash('Failed to get thread data :c')
+      this._playlist.flash('Failed to get thread data, are you sure it exists?')
       console.error(err)
 
       return


### PR DESCRIPTION
## Context

When a user enters an invalid thread URL, 4webm doesn't display any error messages.

## Objective

* Send 404 errors to the client
* Display an error message when thread isn't found

## Lessons learned

* You can't do `res.send(err)`, since the full error object contains circular references, which can't be `JSON.stringify`'d. Try `res.send(err.message)` instead