### PR TITLE
feat(title): Display current video filename above player

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -8,6 +8,7 @@ const player = new Player({
   video: $('#player'),
   status: $('#status'),
   playlist: $('#playlist'),
+  title: $('#filename'),
   save: $('#save')
 })
 

--- a/client/player.js
+++ b/client/player.js
@@ -8,9 +8,11 @@ class Player {
   constructor (dom) {
     this._$video = dom.video
     this._$status = dom.status
+    this._$title = dom.title
     this._$save = dom.save
     this._index = 0
     this._webmUrls = []
+    this._filenames = []
     this._playlist = new Playlist(dom.playlist)
     this._thumbnails = false
 
@@ -37,8 +39,9 @@ class Player {
     const collect = collector(res.data)
 
     this._webmUrls = collect('url')
+    this._filenames = collect('filename')
     this._playlist.gen(
-      collect('filename'),
+      this._filenames,
       collect('thumbnail'),
       this.play.bind(this)
     )
@@ -91,6 +94,7 @@ class Player {
     this._$video.src = this._webmUrls[this._index]
     this._$save.href = this._webmUrls[this._index]
     this._$status.innerHTML = `${this._index + 1} / ${this._webmUrls.length}`
+    this._$title.innerHTML = `${this._filenames[this._index]}.webm`
     window.location.hash = this._index + 1
     this._playlist.update(this._index)
     this._$video.load()

--- a/static/style-blue.css
+++ b/static/style-blue.css
@@ -1,3 +1,6 @@
+body {
+  padding-bottom: 40px;
+}
 .active {
   color: red !important;
 }
@@ -51,4 +54,7 @@
 #menu-misc {
   display: inline-block;
   margin-right: 50px;
+}
+#filename {
+  text-align: center;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -1,3 +1,6 @@
+body {
+  padding-bottom: 40px;
+}
 .active {
   color: red !important;
 }
@@ -51,4 +54,7 @@
 #menu-misc {
   margin-right: 50px;
   display: inline-block;
+}
+#filename {
+  text-align: center;
 }

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -45,6 +45,7 @@
     <div class='body-cnt'>
       <div class="player-cnt">
         <div id="menu">
+          <p id="filename"></p>
           <div id="menu-misc">
             [<a id="save" href="#" download>Save</a>]
             [<a id="fullscreen" class="hide" href="#">Fullscreen</a>]


### PR DESCRIPTION
## Context

webms often have humorous or enlightening filenames. Currently, 4webm does not display the current video's filename near the player (however, it is shown in the playlist).

## Objective

* Display the current video filename above the player

## Lessons learned

* FLCL seems like a pretty dank anime