### PR TITLE
fix(22): Remove save button

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -8,8 +8,7 @@ const player = new Player({
   video: $('#player'),
   status: $('#status'),
   playlist: $('#playlist'),
-  title: $('#filename'),
-  save: $('#save')
+  title: $('#filename')
 })
 
 if (fscreen.fullscreenEnabled) {

--- a/client/player.js
+++ b/client/player.js
@@ -10,7 +10,6 @@ class Player {
     this._$video = dom.video
     this._$status = dom.status
     this._$title = dom.title
-    this._$save = dom.save
     this._index = 0
     this._webmUrls = []
     this._filenames = []
@@ -100,7 +99,6 @@ class Player {
 
   _play () {
     this._$video.src = this._webmUrls[this._index]
-    this._$save.href = this._webmUrls[this._index]
     this._$status.innerHTML = `${this._index + 1} / ${this._webmUrls.length}`
     this._$title.innerHTML = `${this._filenames[this._index]}.webm`
     window.location.hash = this._index + 1

--- a/static/style-blue.css
+++ b/static/style-blue.css
@@ -53,7 +53,7 @@ body {
 }
 #menu-misc {
   display: inline-block;
-  margin-right: 50px;
+  margin-right: 165px;
 }
 #filename {
   text-align: center;

--- a/static/style.css
+++ b/static/style.css
@@ -52,7 +52,7 @@ body {
   display: inline-block;
 }
 #menu-misc {
-  margin-right: 50px;
+  margin-right: 165px;
   display: inline-block;
 }
 #filename {

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -47,7 +47,6 @@
         <div id="menu">
           <p id="filename"></p>
           <div id="menu-misc">
-            [<a id="save" href="#" download>Save</a>]
             [<a id="fullscreen" class="hide" href="#">Fullscreen</a>]
           </div>
           <label>
@@ -62,7 +61,7 @@
           </form>
           <span id="status"></span>
         </div>
-        <video id="player" width="650" height="400" controls>
+        <video id="player" width="650" height="400" controls autoplay>
           Your browser does not support the video tag! ;-;
         </video>
       </div>


### PR DESCRIPTION
## Context

The `[Save]` button currently is not functioning properly, due to browsers changing behavior when saving files from a different origin.

## Objective

* Remove save button
  * Users can still save videos by right clicking on the video player and selecting "Save As"

## References

* Issue: https://github.com/ScottyFillups/4webm/issues/22