### PR TITLE
feat: Add additional keyboard shortcuts

### DIFF
--- a/client/index.js
+++ b/client/index.js
@@ -11,7 +11,9 @@ const remote = {
   prev: 'left',
   toggle: 'space',
   fullscreen: 'f',
-  loop: 'l'
+  loop: 'l',
+  lowerVolume: 'down',
+  raiseVolume: 'up'
 }
 const player = new Player({
   video: $('#player'),
@@ -30,7 +32,9 @@ player.on('change', (state) => {
 registerRemote(remote, player)
 
 document.body.addEventListener('keydown', (e) => {
-  if (keycode(e) === 'space') {
+  const ignore = ['space', 'up', 'down']
+
+  if (ignore.includes(keycode(e))) {
     e.preventDefault()
   }
 })

--- a/client/index.js
+++ b/client/index.js
@@ -8,14 +8,17 @@ import { $ } from './util'
 const remote = {
   next: 'right',
   prev: 'left',
-  toggle: 'space'
+  toggle: 'space',
+  fullscreen: 'f',
+  loop: 'l'
 }
 const player = new Player({
   video: $('#player'),
   status: $('#status'),
   playlist: $('#playlist'),
   title: $('#filename'),
-  save: $('#save')
+  save: $('#save'),
+  loop: $('#loop')
 })
 
 document.body.addEventListener('keydown', (e) => {
@@ -37,10 +40,6 @@ if (fscreen.fullscreenEnabled) {
 if (window.location.pathname !== '/') {
   player.load(window.location.href)
 }
-
-$('#loop').addEventListener('click', e => {
-  player.loop = $('#loop').checked
-})
 
 $('#thread-form').addEventListener('submit', e => {
   e.preventDefault()

--- a/client/index.js
+++ b/client/index.js
@@ -3,6 +3,7 @@
 import keycode from 'keycode'
 import fscreen from 'fscreen'
 import Player from './player'
+import registerRemote from './remote'
 import { $ } from './util'
 
 const remote = {
@@ -14,20 +15,25 @@ const remote = {
 }
 const player = new Player({
   video: $('#player'),
-  status: $('#status'),
-  playlist: $('#playlist'),
-  title: $('#filename'),
-  loop: $('#loop'),
-  title: $('#filename')
+  playlist: $('#playlist')
 })
+
+player.on('change', (state) => {
+  console.log(state)
+
+  $('#status').innerHTML = `${state.index + 1} / ${state.total}`
+  $('#filename').innerHTML = `${state.title}.webm`
+  $('#filename').href = state.url
+  $('#loop').checked = state.loop
+})
+
+registerRemote(remote, player)
 
 document.body.addEventListener('keydown', (e) => {
   if (keycode(e) === 'space') {
     e.preventDefault()
   }
 })
-
-player.registerRemote(remote)
 
 if (fscreen.fullscreenEnabled) {
   $('#fullscreen').classList.remove('hide')

--- a/client/player.js
+++ b/client/player.js
@@ -12,6 +12,7 @@ class Player {
     this._$status = dom.status
     this._$title = dom.title
     this._$save = dom.save
+    this._$loop = dom.loop
     this._index = 0
     this._webmUrls = []
     this._filenames = []
@@ -20,6 +21,9 @@ class Player {
 
     this._$video.addEventListener('canplay', this._$video.play)
     this._$video.addEventListener('ended', this.next.bind(this))
+    this._$loop.addEventListener('click', (e) => {
+      this.loop = this._$loop.checked
+    })
   }
 
   async load (threadUrl) {
@@ -62,7 +66,7 @@ class Player {
     this.play(index)
   }
 
-  registerRemote ({ toggle, next, prev }) {
+  registerRemote ({ toggle, next, prev, fullscreen, loop }) {
     const handler = (e) => {
       e.preventDefault()
 
@@ -78,6 +82,12 @@ class Player {
         this.next()
       } else if (key === prev) {
         this.prev()
+      } else if (key === fullscreen) {
+        if (this._$video.requestFullscreen) {
+          this._$video.requestFullscreen()
+        }
+      } else if (key === loop) {
+        this._toggleLoop()
       }
     }
 
@@ -118,8 +128,14 @@ class Player {
     this._playlist.hideThumbnails()
   }
 
+  _toggleLoop () {
+    this._$video.loop = !this._$video.loop
+    this._$loop.checked = !this._$loop.checked
+  }
+
   set loop (toggle) {
     this._$video.loop = toggle
+    this._$loop.checked = toggle
   }
 
   _play () {

--- a/client/player.js
+++ b/client/player.js
@@ -116,6 +116,7 @@ class Player {
 
   toggleLoop () {
     this.state = { loop: !(this.state.loop) }
+    this.$video.loop = this.state.loop
   }
 
   on (...args) {

--- a/client/player.js
+++ b/client/player.js
@@ -1,28 +1,36 @@
 'use strict'
 
 import * as axios from 'axios'
-import keycode from 'keycode'
 import boards from '4chan-boards'
 import Playlist from './playlist'
+import Reactor from './reactor'
 import { collector } from './util'
 
 class Player {
+  /**
+   * Create a 4webm player
+   * @param {object}  dom
+   * @param {Element} dom.video
+   * @param {Element} dom.playlist
+   */
   constructor (dom) {
-    this._$video = dom.video
-    this._$status = dom.status
-    this._$title = dom.title
-    this._$loop = dom.loop
-    this._index = 0
+    this.$video = dom.video
+    this._state = {
+      index: 0,
+      total: 0,
+      loop: false,
+      title: '',
+      url: '',
+      paused: false
+    }
+
     this._webmUrls = []
     this._filenames = []
     this._playlist = new Playlist(dom.playlist)
-    this._thumbnails = false
+    this._reactor = new Reactor()
 
-    this._$video.addEventListener('canplay', this._$video.play)
-    this._$video.addEventListener('ended', this.next.bind(this))
-    this._$loop.addEventListener('click', (e) => {
-      this.loop = this._$loop.checked
-    })
+    this.$video.addEventListener('canplay', this.$video.play)
+    this.$video.addEventListener('ended', this.next.bind(this))
   }
 
   async load (threadUrl) {
@@ -62,88 +70,69 @@ class Player {
       ? Number(fragment) - 1
       : 0
 
+    this.state = { total: this._webmUrls.length }
     this.play(index)
   }
 
-  registerRemote ({ toggle, next, prev, fullscreen, loop }) {
-    const handler = (e) => {
-      e.preventDefault()
+  play (index) {
+    this.state = { paused: false }
 
-      const key = keycode(e)
-
-      if (key === toggle) {
-        if (this._$video.paused === true) {
-          this._$video.play()
-        } else {
-          this._$video.pause()
-        }
-      } else if (key === next) {
-        this.next()
-      } else if (key === prev) {
-        this.prev()
-      } else if (key === fullscreen) {
-        if (this._$video.requestFullscreen) {
-          this._$video.requestFullscreen()
-        }
-      } else if (key === loop) {
-        this._toggleLoop()
+    if (index < this._webmUrls.length && index >= 0) {
+      this.state = {
+        index,
+        title: this._filenames[index],
+        url: this._webmUrls[index]
       }
-    }
 
-    document.body.removeEventListener('keyup', handler)
-    document.body.addEventListener('keyup', handler)
+      this.$video.src = this._webmUrls[index]
+      window.location.hash = index + 1
+      this._playlist.update(index)
+      this.$video.load()
+    } else {
+      this.$video.play()
+    }
   }
 
-  play (index) {
-    if (index < this._webmUrls.length && index >= 0) {
-      this._index = index
-      this._play()
-    }
+  pause () {
+    this.state = { paused: true }
+    this.$video.pause()
   }
 
   next () {
-    if (this._webmUrls.length - 1 > this._index) {
-      this.play(this._index + 1)
+    if (this._webmUrls.length - 1 > this.state.index) {
+      this.play(this.state.index + 1)
     } else {
       this.play(0)
     }
   }
 
   prev () {
-    if (this._index > 0) {
-      this.play(this._index - 1)
+    if (this.state.index > 0) {
+      this.play(this.state.index - 1)
     } else {
       this.play(this._webmUrls.length - 1)
     }
   }
 
-  showThumbnails () {
-    this._thumbnails = true
-    this._playlist.showThumbnails()
+  toggleLoop () {
+    this.state = { loop: !(this.state.loop) }
   }
 
-  hideThumbnails () {
-    this._thumbnails = false
-    this._playlist.hideThumbnails()
+  on (...args) {
+    this._reactor.on(...args)
   }
 
-  _toggleLoop () {
-    this._$video.loop = !this._$video.loop
-    this._$loop.checked = !this._$loop.checked
+  _emit (...args) {
+    this._reactor.emit(...args)
   }
 
-  set loop (toggle) {
-    this._$video.loop = toggle
-    this._$loop.checked = toggle
+  get state () {
+    return this._state
   }
 
-  _play () {
-    this._$video.src = this._webmUrls[this._index]
-    this._$status.innerHTML = `${this._index + 1} / ${this._webmUrls.length}`
-    this._$title.innerHTML = `${this._filenames[this._index]}.webm`
-    window.location.hash = this._index + 1
-    this._playlist.update(this._index)
-    this._$video.load()
+  set state (partial) {
+    Object.assign(this._state, partial)
+    this._emit('change', this.state)
   }
 }
 

--- a/client/reactor.js
+++ b/client/reactor.js
@@ -1,0 +1,17 @@
+'use strict'
+
+class Reactor {
+  constructor () {
+    this._events = {}
+  }
+
+  on (event, handler) {
+    this._events[event] = handler
+  }
+
+  emit (event, data) {
+    this._events[event](data)
+  }
+}
+
+export default Reactor

--- a/client/remote.js
+++ b/client/remote.js
@@ -4,7 +4,15 @@ import keycode from 'keycode'
 import fscreen from 'fscreen'
 
 function registerRemote (buttons, player) {
-  const { toggle, next, prev, fullscreen, loop } = buttons
+  const {
+    toggle,
+    next,
+    prev,
+    fullscreen,
+    loop,
+    raiseVolume,
+    lowerVolume
+  } = buttons
 
   const handler = (e) => {
     e.preventDefault()
@@ -23,8 +31,14 @@ function registerRemote (buttons, player) {
       player.prev()
     } else if (key === loop) {
       player.toggleLoop()
-    } else if (key === fullscreen) {
-      if (fscreen.requestFullscreen) {
+    } else if (key === lowerVolume) {
+      player.$video.volume -= 10 / 100
+    } else if (key === raiseVolume) {
+      player.$video.volume += 10 / 100
+    } else if (key === fullscreen && fscreen.fullscreenEnabled) {
+      if (fscreen.fullscreenElement !== null) {
+        fscreen.exitFullscreen()
+      } else {
         fscreen.requestFullscreen(player.$video)
       }
     }

--- a/client/remote.js
+++ b/client/remote.js
@@ -1,0 +1,37 @@
+'use strict'
+
+import keycode from 'keycode'
+import fscreen from 'fscreen'
+
+function registerRemote (buttons, player) {
+  const { toggle, next, prev, fullscreen, loop } = buttons
+
+  const handler = (e) => {
+    e.preventDefault()
+
+    const key = keycode(e)
+
+    if (key === toggle) {
+      if (player.state.paused) {
+        player.play()
+      } else {
+        player.pause()
+      }
+    } else if (key === next) {
+      player.next()
+    } else if (key === prev) {
+      player.prev()
+    } else if (key === loop) {
+      player.toggleLoop()
+    } else if (key === fullscreen) {
+      if (fscreen.requestFullscreen) {
+        fscreen.requestFullscreen(player.$video)
+      }
+    }
+  }
+
+  document.body.removeEventListener('keyup', handler)
+  document.body.addEventListener('keyup', handler)
+}
+
+export default registerRemote

--- a/static/style-blue.css
+++ b/static/style-blue.css
@@ -57,6 +57,7 @@ body {
 }
 #filename {
   text-align: center;
+  display: block;
 }
 .subject {
   color: #0f0c5d;

--- a/static/style-blue.css
+++ b/static/style-blue.css
@@ -22,6 +22,7 @@ body {
   text-align: center;
 }
 .player-cnt {
+  margin-top: 10px;
   text-align: left;
   width: 660px;
   display: inline-block;

--- a/static/style.css
+++ b/static/style.css
@@ -22,6 +22,7 @@ body {
   text-align: center;
 }
 .player-cnt {
+  margin-top: 10px;
   text-align: left;
   width: 660px;
   display: inline-block;

--- a/static/style.css
+++ b/static/style.css
@@ -57,6 +57,7 @@ body {
 }
 #filename {
   text-align: center;
+  display: block;
 }
 .subject {
   color: #cc1105;

--- a/util/messages.js
+++ b/util/messages.js
@@ -1,7 +1,7 @@
 const bannerMsgs = [
   `
 You can also load a thread by replacing '4chan' with '4webm' in a thread URL and visiting it`,
-  `Left/right arrow keys now skip to prev/next video, and spacebar toggles pause/play`
+  `Keyboard shortcuts: Left/right -> prev/next, up/down -> volume, spacebar -> pause/play, l -> loop, f -> fullscreen`
 ]
 
 const invalidMsg = `

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -45,7 +45,9 @@
     <div class='body-cnt'>
       <div class="player-cnt">
         <div id="menu">
-          <a id="filename" href=""></a>
+          <div class="fileText">
+            <a id="filename" href=""></a>
+          </div>
           <div id="menu-misc">
             [<a id="fullscreen" class="hide" href="#">Fullscreen</a>]
           </div>

--- a/views/index.hbs
+++ b/views/index.hbs
@@ -45,7 +45,7 @@
     <div class='body-cnt'>
       <div class="player-cnt">
         <div id="menu">
-          <p id="filename"></p>
+          <a id="filename" href=""></a>
           <div id="menu-misc">
             [<a id="fullscreen" class="hide" href="#">Fullscreen</a>]
           </div>


### PR DESCRIPTION
## Context

Currently only prev/next and play/pause keyboard shortcuts exist. Ideally 4webm should have shortcuts for other features, such as enabling fullscreen or toggling looping.

## Objective

* Add fullscreen, loop, and volume keyboard shortcuts
* Refactor code to decouple "accessories" from `player.js`
  * `player.js` will now keep track of state, and emit an event when state changes
  * DOM manipulation is now handled by the client in the event handler instead

## Lessons learned

* See reactor.js for a simple example of how to implement an event system