### PR TITLE
fix(30): Fix history write on hash change

### DIFF
--- a/client/player.js
+++ b/client/player.js
@@ -85,7 +85,7 @@ class Player {
       }
 
       this.$video.src = this._webmUrls[index]
-      history.replaceState(null, null, `#${index + 1}`)
+      window.history.replaceState(null, null, `#${index + 1}`)
       this._playlist.update(index)
       this.$video.load()
     } else {

--- a/client/player.js
+++ b/client/player.js
@@ -85,7 +85,7 @@ class Player {
       }
 
       this.$video.src = this._webmUrls[index]
-      window.location.hash = index + 1
+      history.replaceState(null, null, `#${index + 1}`)
       this._playlist.update(index)
       this.$video.load()
     } else {


### PR DESCRIPTION
## Context

Currently 4webm changes the hash using `window.location.hash = ...`, which writes a new entry in the user's browser history. As a result it's difficult to return to 4chan, since you'll need to click the "previous" button N times, where N is the number of videos you loaded.

## Objective

* Don't pollute user browser history on video change
* Allow users to return to a 4chan thread by clicking the "previous" button once

## References

Issue: https://github.com/ScottyFillups/4webm/issues/30
Tutorial for history API: http://lea.verou.me/2011/05/change-url-hash-without-page-jump/