### PR TITLE
feat(29): Sync scrollbar to playlist state

### DIFF
--- a/client/playlist.js
+++ b/client/playlist.js
@@ -23,6 +23,7 @@ class Playlist {
       const num = i + 1
 
       $a.innerHTML = `${num}. ${filename}.webm`
+      $a.id = num
       $a.className = 'webm-link'
       $a.addEventListener('click', () => handler(i))
 

--- a/client/playlist.js
+++ b/client/playlist.js
@@ -23,7 +23,6 @@ class Playlist {
       const num = i + 1
 
       $a.innerHTML = `${num}. ${filename}.webm`
-      $a.id = num
       $a.className = 'webm-link'
       $a.addEventListener('click', () => handler(i))
 
@@ -48,6 +47,7 @@ class Playlist {
       .forEach((elem, i) => {
         if (index === i) {
           elem.classList.add(classname)
+          elem.scrollIntoView()
         } else {
           elem.classList.remove(classname)
         }

--- a/static/style-blue.css
+++ b/static/style-blue.css
@@ -41,8 +41,8 @@ body {
   word-wrap: break-word;
   display: inline-block;
   vertical-align: top;
-  margin: 10px;
-} 
+  padding: 10px;
+}
 .playlist-item {
   margin: 5px;
 }

--- a/static/style.css
+++ b/static/style.css
@@ -41,8 +41,8 @@ body {
   word-wrap: break-word;
   display: inline-block;
   vertical-align: top;
-  margin: 10px;
-} 
+  padding: 10px;
+}
 .playlist-item {
   margin: 5px;
 }


### PR DESCRIPTION
## Context

The playlist scrollbar is not in sync with the playlist state, forcing users to manually scroll down to see the upcoming videos.

## Objective

* Update the scrollbar to always position the active video at the top

## References

Issue: https://github.com/ScottyFillups/4webm/issues/29
scrollIIntoView documentation: https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView