### PR TITLE
feat: No playlist snap on item click

### DIFF
--- a/client/player/player.js
+++ b/client/player/player.js
@@ -64,7 +64,7 @@ class Player {
       this._filenames,
       collect('thumbnail'),
       res.data.subject,
-      this.play.bind(this)
+      (i) => this.play(i, false)
     )
 
     const index = fragment && Number(fragment) <= this._webmUrls.length
@@ -85,7 +85,12 @@ class Player {
     }
   }
 
-  play (index) {
+  /**
+   * @method play
+   * @param {number}  index  Index of the video to play
+   * @param {boolean} [snap=true]   Determines whether playlist will auto scroll
+   */
+  play (index, snap = true) {
     this.state.set({ paused: false })
 
     if (index < this._webmUrls.length && index >= 0) {
@@ -97,7 +102,7 @@ class Player {
 
       this._$video.src = this._webmUrls[index]
       window.history.replaceState(null, null, `#${index + 1}`)
-      this._playlist.update(index)
+      this._playlist.update(index, snap)
       this._$video.load()
     } else {
       this.play(this.state.index)

--- a/client/player/playlist.js
+++ b/client/player/playlist.js
@@ -39,7 +39,7 @@ class Playlist {
     })
   }
 
-  update (index, classname = 'active') {
+  update (index, snap = true, classname = 'active') {
     Array.from(this._$playlist.childNodes)
       .filter(x => x.tagName === 'DIV')
       .map(item => Array.from(item.childNodes))
@@ -47,7 +47,10 @@ class Playlist {
       .forEach((elem, i) => {
         if (index === i) {
           elem.classList.add(classname)
-          elem.scrollIntoView()
+
+          if (snap) {
+            elem.scrollIntoView()
+          }
         } else {
           elem.classList.remove(classname)
         }


### PR DESCRIPTION
## Context

Currently the playlist will always call `scrollIntoView`, which can be annoying when manually previewing videos. Ideally `scrollIntoView` should only be called when:

* The video has ended, and the player is transitioning to the next video
* The prev/next commands have been fired

## Objective

* Prevent playlist "snapping" when manually selecting videos