### PR TITLE
feat(42): Add seeking keyboard shortcuts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-/node_modules
-/thumbnail
+node_modules/
+thumbnail/
+.cache/
 *.swo
-dump.rdb
-static/bundle.js
 *.swp
 *.log
 TODO.md
+dump.rdb
+static/bundle.js

--- a/client/index.js
+++ b/client/index.js
@@ -13,6 +13,8 @@ const controls = {
   fullscreen: 'f',
   loop: 'l',
   mute: 'm',
+  seekForward: '.',
+  seekBackward: ',',
   lowerVolume: 'down',
   raiseVolume: 'up'
 }

--- a/client/player/player.js
+++ b/client/player/player.js
@@ -6,6 +6,7 @@ import Playlist from './playlist'
 import Remote from './remote'
 import State from './state'
 import Speaker from './speaker'
+import Seeker from './seeker'
 import { regex, collector } from '../util'
 
 class Player {
@@ -18,6 +19,7 @@ class Player {
   constructor (dom) {
     this._$video = dom.video
     this.speaker = new Speaker(this._$video)
+    this.seek = new Seeker(this._$video)
     this.remote = new Remote(this)
     this.state = new State({
       index: 0,
@@ -25,7 +27,7 @@ class Player {
       loop: false,
       title: '',
       url: '',
-      paused: true
+      paused: this._$video.paused
     })
 
     this._webmUrls = []
@@ -96,7 +98,11 @@ class Player {
    * @param {boolean} [snap=true]   Determines whether playlist will auto scroll
    */
   play (index, snap = true) {
-    if (index < this._webmUrls.length && index >= 0) {
+    if (index === this.state.index) {
+      this.state.set({ paused: false })
+
+      this._$video.play()
+    } else if (index < this._webmUrls.length && index >= 0) {
       this.state.set({
         index,
         title: this._filenames[index],
@@ -109,8 +115,6 @@ class Player {
       this._playlist.update(index, snap)
       this._$video.load()
     } else {
-      this.state.set({ paused: false })
-
       this.play(this.state.index)
     }
   }

--- a/client/player/remote.js
+++ b/client/player/remote.js
@@ -16,6 +16,8 @@ class Remote {
       fullscreen,
       loop,
       mute,
+      seekForward,
+      seekBackward,
       raiseVolume,
       lowerVolume
     } = buttons
@@ -48,6 +50,12 @@ class Remote {
           break
         case mute:
           this._player.speaker.toggle()
+          break
+        case seekForward:
+          this._player.seek.forward()
+          break
+        case seekBackward:
+          this._player.seek.backward()
           break
         case fullscreen:
           if (fscreen.fullscreenEnabled) {

--- a/client/player/seeker.js
+++ b/client/player/seeker.js
@@ -1,0 +1,30 @@
+'use strict'
+
+import { createClamp } from '../util'
+
+class Seeker {
+  constructor ($video, step = 0.10) {
+    this._$video = $video
+    this.step = step
+  }
+
+  _clamp (val) {
+    return createClamp(0, this._$video.duration)(val)
+  }
+
+  forward () {
+    if (this._$video.readyState > 0) {
+      const { currentTime, duration } = this._$video
+      this._$video.currentTime = this._clamp(currentTime + duration * this.step)
+    }
+  }
+
+  backward () {
+    if (this._$video.readyState > 0) {
+      const { currentTime, duration } = this._$video
+      this._$video.currentTime = this._clamp(currentTime - duration * this.step)
+    }
+  }
+}
+
+export default Seeker


### PR DESCRIPTION
## Context

There are no keyboard shortcuts for video seeking; changing the video time must be done via mouse.

## Objective

* Add controls for seeking: `,` and `.` for backwards and forwards, respectively

## References

* Issue: https://github.com/ScottyFillups/4webm/issues/42